### PR TITLE
Ajout de l'adresse contact@signalconso.beta.gouv.fr

### DIFF
--- a/config.js
+++ b/config.js
@@ -89,6 +89,10 @@ const config = {
       description: "Liste des redirections sur contact@reso.beta.gouv.fr"
     },
     {
+      id: "contact@signalconso.beta.gouv.fr",
+      description: "L'équipe SignalConso (ex-Signalement)"
+    },
+    {
       id: "contact@signalement.beta.gouv.fr",
       description: "Liste des redirections sur contact@signalement.beta.gouv.fr"
     },


### PR DESCRIPTION
Suite au changement de nom Signalement -> SignalConso, ajout d'une nouvelle adresse de contact.

L'adresse initiale sera supprimée dans un second temps, après diffusion de la nouvelle adresse.