### PR TITLE
Fix spaces in commands

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,8 @@
   "name": "slack-ovh",
   "version": "1.0.0",
   "scripts": {
-    "start": "node ./bin/www"
+    "start": "node ./bin/www",
+    "test": "node tests/config.spec"
   },
   "dependencies": {
     "bluebird": "^3.5.1",
@@ -16,8 +17,5 @@
     "morgan": "~1.9.0",
     "ovh": "^2.0.1",
     "serve-favicon": "~2.4.5"
-  },
-  "scripts": {
-    "test": "node tests/config.spec"
   }
 }

--- a/routes/mails.js
+++ b/routes/mails.js
@@ -164,7 +164,7 @@ router.post('/', verification, function(req, res, next) {
     return help(res)
   }
 
-  let [ cmd, mailingList, email ] = req.body.text.split(' ')
+  let [ cmd, mailingList, email ] = req.body.text.replace(/\s\s+/g, " ").trim().split(" ")
 
   switch(cmd) {
     case 'join':


### PR DESCRIPTION
if for some reason (copy/paste) you have more than one space in the command, arguments wont be detected properly. this should prevent this.