### PR TITLE
Update URL to the guide about mailing list

### DIFF
--- a/routes/mails.js
+++ b/routes/mails.js
@@ -12,7 +12,7 @@ const helpMessage = `Commandes disponibles:
   \t- \`/emails join id_de_la_liste email_a_ajouter@domain.com\`\tinscrire email_a_ajouter@domain.com à la liste email_de_la_liste@domain.com
   \t- \`/emails leave id_de_la_liste email_a_ajouter@domain.com\`\tenlever email_a_ajouter@domain.com de la liste email_de_la_liste@domain.com
 
-  Pour lire comment ajouter une nouvelle liste, c'est ici 👉 https://doc.incubateur.net/communaute/outils/liste-de-diffusion-et-adresses-de-contact#la-commande-slack-emails`;
+  Pour lire comment ajouter une nouvelle liste, c'est ici 👉 https://doc.incubateur.net/communaute/travailler-a-beta-gouv/jutilise-les-outils-de-la-communaute/outils/liste-de-diffusion-et-adresses-de-contact#comment-creer-une-nouvelle-liste-de-diffusion-pour-la-communaute`;
 
 const redirections = config.lists.reduce((acc, current) => {
   if (!current.realMailingList) {


### PR DESCRIPTION
### Problem

The current link is no more available.

### Solution

Set the new and effective link on GitBook